### PR TITLE
FSM 적 코드정리 + 대쉬 구현 + 원거리 회피 절반 구현

### DIFF
--- a/Assets/00.Scenes/NSJ_READY/FSM/FSM.unity
+++ b/Assets/00.Scenes/NSJ_READY/FSM/FSM.unity
@@ -3888,7 +3888,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7441560104420682010, guid: 76fc565d93806e94fb0273c5201c5d9b, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 76fc565d93806e94fb0273c5201c5d9b, type: 3}

--- a/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterAttack.cs
+++ b/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterAttack.cs
@@ -35,9 +35,9 @@ public class BasicMonsterAttack : BaseState
     public override void CheckDistance()
     {
         base.CheckDistance();
-        if (monster.distance > monster.agent.stoppingDistance)
+        if (monster.distance > monster.attackRange)
         {
-            stateMachine.ChangeState(((BasicCloseMonster)stateMachine).idleState);
+            stateMachine.ChangeState(monster.idleState);
         }
     }
 

--- a/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterDamage.cs
+++ b/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterDamage.cs
@@ -12,12 +12,6 @@ public class BasicMonsterDamage : BaseState
 {
     BasicCloseMonster monster;
 
-    float delayTime = 1.0f;
-    float nowDelay = 0.0f;
-
-    float HP = 100f;
-    float damage = 20f;
-
     // 데미지 생성자
     public BasicMonsterDamage(BasicCloseMonster stateMachine) : base("DAMAGED", stateMachine)
     {
@@ -25,6 +19,11 @@ public class BasicMonsterDamage : BaseState
     }
 
     #region DAMAGE
+    float delayTime = 1.0f;
+    float nowDelay = 0.0f;
+
+    float HP = 100f;
+    float damage = 20f;
 
     public float GetHP => HP;
 
@@ -64,11 +63,11 @@ public class BasicMonsterDamage : BaseState
         base.CheckDistance();
         if (HP <= 0)
         {
-            stateMachine.ChangeState(((BasicCloseMonster)stateMachine).dieState);
+            stateMachine.ChangeState(monster.dieState);
         }
         if (nowDelay >= delayTime)
         {
-            stateMachine.ChangeState(((BasicCloseMonster)stateMachine).idleState);
+            stateMachine.ChangeState(monster.idleState);
         }
 
     }

--- a/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterIdle.cs
+++ b/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterIdle.cs
@@ -26,11 +26,11 @@ public class BasicMonsterIdle : BaseState
 
         if (monster.distance <= monster.attackRange)
         {
-            stateMachine.ChangeState(((BasicCloseMonster)stateMachine).attackState);
+            stateMachine.ChangeState(monster.attackState);
         }
         else if (monster.distance <= monster.moveRange)
         {
-            stateMachine.ChangeState(((BasicCloseMonster)stateMachine).moveState);
+            stateMachine.ChangeState(monster.moveState);
         }
     }
 

--- a/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterMove.cs
+++ b/Assets/01.Scripts/FSM/CloseMonsterState/BasicMonsterMove.cs
@@ -20,12 +20,15 @@ public class BasicMonsterMove : BaseState
     }
 
     #region DASH 
-    private bool isDash = false;
+    private const float dashCoolTime = Define.DASH_COOLTIME;
+    private const float dashDuration = Define.DASH_DURATION;
+    private const float dashDistance = 25f;
+
     private bool CanDash => dashTime <= 0f;
-    private float dashCoolTime = 2.0f;
-    private float dashTime = 0;
-    private float dashDistance = 25f;
+    private bool isDash = false;
+    
     private float dashSpeed = 100f;
+    private float dashTime = 0;
 
     private void CheckDash()
     {
@@ -52,7 +55,7 @@ public class BasicMonsterMove : BaseState
     private void SetUseCoolTime()
     {
         dashTime += Time.deltaTime;
-        if (dashTime >= Define.DASH_DURATION)
+        if (dashTime >= dashDuration)
         {
             StopDash();
         }
@@ -85,10 +88,10 @@ public class BasicMonsterMove : BaseState
 
     private void Move()
     {
+        if (target == null) return;
         monster.LookTarget(target);
         monster.agent.SetDestination(target.position);
     }
-
     private void SetMove(bool isMove)
     {
         monster.agent.isStopped = !isMove;
@@ -108,11 +111,12 @@ public class BasicMonsterMove : BaseState
 
     #region STATE
 
+
     // 다른 STATE로 넘어가는 조건
     public override void CheckDistance()
     {
         base.CheckDistance();
-        if (monster.agent.remainingDistance <= monster.agent.stoppingDistance)
+        if (monster.distance <= monster.attackRange)
         {
             stateMachine.ChangeState(monster.idleState);
         }

--- a/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterAttack.cs
+++ b/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterAttack.cs
@@ -12,13 +12,96 @@ public class FarMonsterAttack : BaseState
     BasicFarMonster monster;
     Transform target;
 
-    //float attackDelay = 3.0f;
-    //float nowAttackcool = 0.0f;
-
     // 생성자
     public FarMonsterAttack(BasicFarMonster stateMachine) : base("ATTACK", stateMachine)
     {
         monster = (BasicFarMonster)stateMachine;
+    }
+
+    #region AVOID
+
+    private const float avoidCoolTime = Define.AVOID_COOLTIME;
+    private const float avoidDuration = Define.AVOID_DURATION;
+    private const float avoidDistance = 25f;
+
+    private bool CanAvoid => avoidTime <= 0f;
+    private bool isAvoid = false;
+
+    private float avoidTime = 0;
+    private float avoidSpeed = 100f;
+
+    private void CheckAvoid()
+    {
+        if (isAvoid) return;
+        if (monster.distance <= avoidDistance && CanAvoid)
+        {
+            Avoid(monster.dir * -1);
+        }
+    }
+
+    private void CheckAvoidCoolTime()
+    {
+        if (isAvoid)
+        {
+            SetUseCoolTime();
+        }
+        else
+        {
+            if (CanAvoid) return;
+            SetReadyCoolTime();
+        }
+    }
+
+    private void SetUseCoolTime()
+    {
+        avoidTime += Time.deltaTime;
+        if (avoidTime >= avoidDuration)
+        {
+            StopAvoid();
+        }
+    }
+    private void SetReadyCoolTime()
+    {
+        avoidTime -= Time.deltaTime;
+    }
+
+    private void Avoid(Vector3 velocity)
+    {
+        isAvoid = true;
+
+        monster.rigid.AddForce(velocity.normalized * avoidSpeed, ForceMode.Impulse);
+
+    }
+
+    private void StopAvoid()
+    {
+        avoidTime = avoidCoolTime;
+        monster.rigid.velocity = Vector3.zero;
+        isAvoid = false;
+    }
+
+
+    #endregion
+
+    #region ANIMATION
+
+    public override void SetAnim(bool isPlay)
+    {
+        base.SetAnim(isPlay);
+        monster.AttackAnimation(isPlay);
+    }
+
+    #endregion
+
+    #region STATE
+
+    public override void CheckDistance()
+    {
+        base.CheckDistance();
+        if (monster.distance > monster.attackRange)
+        {
+            stateMachine.ChangeState(monster.idleState);
+        }
     }
 
     // 상태 시작 시
@@ -26,7 +109,7 @@ public class FarMonsterAttack : BaseState
     public override void Enter()
     {
         base.Enter();
-        monster.anim.SetBool(monster.hashAttack, true);
+        SetAnim(true);
     }
 
     // Attack Animation에 이벤트로 추가해서 애니메이션 박자에 맞게 쏘도록 함
@@ -35,12 +118,10 @@ public class FarMonsterAttack : BaseState
     {
         base.UpdateLogic();
         target = monster.SerachTarget();
+        monster.LookTarget(target);
 
-        if (monster.distance > monster.agent.stoppingDistance)
-        {
-            stateMachine.ChangeState(((BasicFarMonster)stateMachine).idleState);
-        }
-        if(target) monster.LookTarget(target);
+        CheckAvoid();
+        CheckAvoidCoolTime();
     }
 
     // 상태 끝났을 시
@@ -48,6 +129,9 @@ public class FarMonsterAttack : BaseState
     public override void Exit()
     {
         base.Exit();
-        monster.anim.SetBool(monster.hashAttack, false);
+        SetAnim(false);
     }
+
+    #endregion
+
 }

--- a/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterBullet.cs
+++ b/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterBullet.cs
@@ -12,13 +12,6 @@ public class FarMonsterBullet : Poolable
 
     float moveSpeed = 20f;
     float deleteTime = 2.0f;
-
-    public override void ResetData()
-    {
-        // 초기화
-        // 아직 없음
-    }
-
     private void Awake()
     {
         rigid = GetComponent<Rigidbody>();
@@ -36,6 +29,12 @@ public class FarMonsterBullet : Poolable
         {
             rigid.position += transform.forward * (moveSpeed * Time.deltaTime);
         }
+    }
+
+    public override void ResetData()
+    {
+        // 초기화
+        // 아직 없음
     }
 
     // 플레이어 공격 성공 시

--- a/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterDamage.cs
+++ b/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterDamage.cs
@@ -8,16 +8,64 @@ public class FarMonsterDamage : BaseState
 {
     BasicFarMonster monster;
 
+    // 생성자
+    public FarMonsterDamage(BasicFarMonster stateMachine) : base("DAMAGED", stateMachine)
+    {
+        monster = (BasicFarMonster)stateMachine;
+    }
+
+    #region DAMAGE
     float delayTime = 1.0f; // 무적 시간
     float nowDelay = 0.0f;
 
     float HP = 100f; // 체력
     float damage = 20f; // 데미지 입을 크기
 
-    // 생성자
-    public FarMonsterDamage(BasicFarMonster stateMachine) : base("DAMAGED", stateMachine)
+    public float GetHP => HP;
+
+    private void SetHP(bool isHeal, float plusHP)
     {
-        monster = (BasicFarMonster)stateMachine;
+        if (isHeal)
+        {
+            HP += plusHP;
+        }
+        else
+        {
+            HP -= plusHP;
+        }
+    }
+
+    private void SetDelay(float delay)
+    {
+        nowDelay = delay;
+    }
+
+    #endregion
+
+    #region ANIMATION
+
+    public override void SetAnim()
+    {
+        base.SetAnim();
+        monster.DamageAnimation();
+    }
+
+    #endregion
+
+    #region STATE
+
+    public override void CheckDistance()
+    {
+        base.CheckDistance();
+        if (HP <= 0)
+        {
+            stateMachine.ChangeState(monster.dieState);
+        }
+        if (nowDelay >= delayTime)
+        {
+            stateMachine.ChangeState(monster.idleState);
+        }
+
     }
 
     // 상태 시작 시
@@ -26,13 +74,9 @@ public class FarMonsterDamage : BaseState
     public override void Enter()
     {
         base.Enter();
-        nowDelay = 0;
-        HP -= damage;
-        if (HP <= 0)
-        {
-            stateMachine.ChangeState(((BasicFarMonster)stateMachine).dieState);
-        }
-        monster.anim.SetTrigger(monster.hashDamage);
+        SetDelay(0);
+        SetHP(false, damage);
+        SetAnim();
     }
 
     // 일정 시간이 지나면 상태 변환
@@ -40,11 +84,6 @@ public class FarMonsterDamage : BaseState
     {
         base.UpdateLogic();
         nowDelay += Time.deltaTime;
-        if (nowDelay >= delayTime)
-        {
-            stateMachine.ChangeState(((BasicFarMonster)stateMachine).idleState);
-        }
-
     }
 
     // 상태 끝났을 시
@@ -52,4 +91,6 @@ public class FarMonsterDamage : BaseState
     {
         base.Exit();
     }
+
+    #endregion
 }

--- a/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterDie.cs
+++ b/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterDie.cs
@@ -13,18 +13,33 @@ public class FarMonsterDie : BaseState
         monster = (BasicFarMonster)stateMachine;
     }
 
+    #region DIE
+
+    private void ResetMonster()
+    {
+        // 몬스터 초기화 함수
+    }
+
+    #endregion
+
+    #region ANIMATION
+
+    public override void SetAnim(bool isPlay)
+    {
+        base.SetAnim(isPlay);
+        monster.DieAnimation(isPlay);
+    }
+
+    #endregion
+
+    #region STATE
     // 상태 시작 시
     // 죽은 애니메이션 실행
     public override void Enter()
     {
         base.Enter();
-        monster.anim.SetBool(monster.hashDie, true);
+        SetAnim(true);
         ResetMonster();
-    }
-
-    private void ResetMonster()
-    {
-        // 몬스터 초기화 함수
     }
 
     // 상태 끝났을 시
@@ -32,4 +47,6 @@ public class FarMonsterDie : BaseState
     {
         base.Exit();
     }
+
+    #endregion
 }

--- a/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterIdle.cs
+++ b/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterIdle.cs
@@ -15,12 +15,28 @@ public class FarMonsterIdle : BaseState
         monster = (BasicFarMonster)stateMachine;
     }
 
+    #region STATE
+
+    public override void CheckDistance()
+    {
+        base.CheckDistance();
+        if (target == null) return;
+
+        if (monster.distance <= monster.attackRange)
+        {
+            stateMachine.ChangeState(monster.attackState);
+        }
+        else if (monster.distance <= monster.moveRange)
+        {
+            stateMachine.ChangeState(monster.moveState);
+        }
+    }
+
     // 상태 시작 시
     // 타겟 찾기 시작
     public override void Enter()
     {
         base.Enter();
-        target = monster.SerachTarget();
     }
 
     // 타겟이 있다면
@@ -29,24 +45,6 @@ public class FarMonsterIdle : BaseState
     {
         base.UpdateLogic();
         target = monster.SerachTarget();
-
-        if (target)
-        {
-            if (monster.distance <= monster.attackRange)
-            {
-                stateMachine.ChangeState(((BasicFarMonster)stateMachine).attackState);
-            }
-            else if (monster.distance >= monster.moveRange)
-            {
-                stateMachine.ChangeState(((BasicFarMonster)stateMachine).moveState);
-            }
-        }
-    }
-
-    // 물리 연산을 위한 LateUpdate
-    public override void UpdateLate()
-    {
-        base.UpdateLogic();
     }
 
     // 상태 끝났을 시
@@ -54,4 +52,6 @@ public class FarMonsterIdle : BaseState
     {
         base.Exit();
     }
+
+    #endregion
 }

--- a/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterMove.cs
+++ b/Assets/01.Scripts/FSM/FarMonsterState/FarMonsterMove.cs
@@ -16,6 +16,44 @@ public class FarMonsterMove : BaseState
         monster = (BasicFarMonster)stateMachine;
     }
 
+
+    #region MOVE
+
+    private void Move()
+    {
+        if (target == null) return;
+        monster.LookTarget(target);
+        monster.agent.SetDestination(target.position);
+    }
+    private void SetMove(bool isMove)
+    {
+        monster.agent.isStopped = !isMove;
+    }
+
+    #endregion
+
+    #region ANIMATION
+
+    public override void SetAnim(bool isPlay)
+    {
+        base.SetAnim();
+        monster.MoveAnimation(isPlay);
+    }
+
+    #endregion
+
+    #region STATE
+
+    // 다른 STATE로 넘어가는 조건
+    public override void CheckDistance()
+    {
+        base.CheckDistance();
+        if (monster.distance <= monster.attackRange)
+        {
+            stateMachine.ChangeState(monster.idleState);
+        }
+    }
+
     // NavMesh를 이용하여 이동
     // 멈춰있다면 isStopped=false
     // 애니메이션 실행
@@ -23,15 +61,9 @@ public class FarMonsterMove : BaseState
     public override void Enter()
     {
         base.Enter();
-        
-        monster.agent.isStopped = false;
-        monster.anim.SetBool(monster.hashWalk, true);
 
-        target = monster.SerachTarget();
-        if (target)
-        {
-            monster.agent.SetDestination(target.position);
-        }
+        SetMove(true);
+        SetAnim(true);
     }
 
     // 타겟 계속 찾으며 쫓아가기 + 쳐다보기
@@ -41,12 +73,7 @@ public class FarMonsterMove : BaseState
         base.UpdateLogic();
         target = monster.SerachTarget();
 
-        monster.agent.SetDestination(target.position);
-        if (monster.agent.remainingDistance <= monster.agent.stoppingDistance)
-        {
-            stateMachine.ChangeState(((BasicFarMonster)stateMachine).idleState);
-        }
-
+        Move();
     }
 
     // 상태 끝났을 시
@@ -54,9 +81,8 @@ public class FarMonsterMove : BaseState
     public override void Exit()
     {
         base.Exit();
-        monster.anim.SetBool(monster.hashWalk, false);
-        monster.agent.isStopped = true;
+        SetAnim(false);
+        SetMove(false);
     }
-
-
+    #endregion
 }

--- a/Assets/01.Scripts/Monster/BasicFarMonster.cs
+++ b/Assets/01.Scripts/Monster/BasicFarMonster.cs
@@ -8,7 +8,6 @@ using static UnityEditor.PlayerSettings;
 public class BasicFarMonster : StateMachine
 {
     private Transform target = null; // 타겟
-    public float distance => GetDistance(); // 타겟과의 거리
 
     // 상태 스크립트
     public FarMonsterIdle idleState;
@@ -26,6 +25,8 @@ public class BasicFarMonster : StateMachine
     public NavMeshAgent agent;
     [HideInInspector]
     public Animator anim;
+    [HideInInspector]
+    public Rigidbody rigid;
 
     // 필요 변수
     public float moveRange = 25.0f; // 일정 거리 이상이 되면 쫓아감
@@ -50,6 +51,7 @@ public class BasicFarMonster : StateMachine
     {
         agent = GetComponent<NavMeshAgent>();
         anim = GetComponent<Animator>();
+        rigid = GetComponent<Rigidbody>();
 
         // 상태 할당
         idleState = new FarMonsterIdle(this);
@@ -58,9 +60,22 @@ public class BasicFarMonster : StateMachine
         damageState = new FarMonsterDamage(this);
         dieState = new FarMonsterDie(this);
 
-        agent.speed = walkingSpeed;
+        SetMonsterInform();
     }
 
+    #region SET
+
+    public void SetMonsterInform()
+    {
+        agent.speed = walkingSpeed;
+        agent.stoppingDistance = attackRange;
+    }
+
+    #endregion
+
+    #region GET
+    public float distance => GetDistance(); // 타겟과의 거리
+    public Vector3 dir => GetDirection(); // 타겟과의 거리
     // 기본 State 가져오기
     protected override BaseState GetInitState() { return idleState; }
 
@@ -69,6 +84,18 @@ public class BasicFarMonster : StateMachine
     {
         return Vector3.Distance(target.transform.position, transform.position);
     }
+
+    // 타겟과의 방향 구하기
+    protected override Vector3 GetDirection()
+    {
+        Vector3 dir = target.position - transform.position;
+        dir.y = 0;
+        return dir;
+    }
+
+    #endregion
+
+    #region TARGET
 
     // 타겟 찾기
     public Transform SerachTarget()
@@ -91,12 +118,20 @@ public class BasicFarMonster : StateMachine
         transform.rotation = rot;
     }
 
+    #endregion
+
+    #region Damage
+
     // 데미지 입었을 때 호출
     // 데미지 입은 상태로 전환
     public void Damaged()
     {
         ChangeState(damageState);
     }
+
+    #endregion
+
+    #region Shoot
 
     // 발사체 발사 함수
     // 방향 구하고 발사체 각도 변경
@@ -111,4 +146,33 @@ public class BasicFarMonster : StateMachine
         obj.gameObject.SetActive(true);
     }
 
+    #endregion
+
+    #region ANIMATION
+
+    // 이동 애니메이션
+    public void MoveAnimation(bool isOn)
+    {
+        anim.SetBool(hashWalk, isOn);
+    }
+
+    // 공격 애니메이션
+    public void AttackAnimation(bool isOn)
+    {
+        anim.SetBool(hashAttack, isOn);
+    }
+
+    // 죽음 애니메이션
+    public void DieAnimation(bool isOn)
+    {
+        anim.SetBool(hashDie, isOn);
+    }
+
+    // 데미지 입는 애니메이션
+    public void DamageAnimation()
+    {
+        anim.SetTrigger(hashDamage);
+    }
+
+    #endregion
 }

--- a/Assets/01.Scripts/Utils/Define.cs
+++ b/Assets/01.Scripts/Utils/Define.cs
@@ -27,6 +27,13 @@ public class Define
     public const float DASH_DOUBLE_TIME = 0.35f;
     #endregion
 
+    #region AVOID
+
+    public const float AVOID_COOLTIME = 2f;
+    public const float AVOID_DURATION = 0.2f;
+
+    #endregion
+
     #region EVENT
     public const short ON_END_READ_DATA = 1000;
     #endregion


### PR DESCRIPTION
### **적 코드정리**

-  이런식으로 region으로 이름 정해놓고 나눠놓음
- 기본적으로 STATE, ANIMAITON이 존재하고 스크립트에 따라 더 추가됨

![image](https://user-images.githubusercontent.com/77655325/201067904-ae811d86-b741-4040-9d89-2738f9a1fc34.png)


### **_적 근거리 대쉬_**

### **대쉬 조건 확인**
**CheckDash**

![image](https://user-images.githubusercontent.com/77655325/201070358-b3889772-144b-4b85-af8d-aaf97ecc4744.png)
![image](https://user-images.githubusercontent.com/77655325/201068912-b1f04db6-52a1-44a8-88a6-a926d425beaf.png)

- 만약 대쉬 중이면 return 한다
- 적과 플레이어의 거리가 대쉬 거리보다 크거나 같고 + CanDash로 대쉬 쿨타임 체크
- 조건에 맞다면 Dash(대쉬 방향) 함수 호출

### **쿨타임 타이머**

**CheckDashCoolTime**

![image](https://user-images.githubusercontent.com/77655325/201068943-79d6f216-5bcb-49c1-876e-bf8e4fbbc576.png)

- 대쉬 중이면 대쉬 시간 시작
- 대쉬 중이 아니라면 CoolTime이 다 돌았는지 체크 + 다 돌지 않았다면 SetReadyCoolTime으로 쿨타임 돌리기

**SetUseCoolTime, SetReadyCoolTime**

![image](https://user-images.githubusercontent.com/77655325/201069014-05350ac0-86d4-443c-9a3e-4a8096eb7dd9.png)

- 대쉬 중이면 대쉬 타이머 SetUseCoolTime() 호출해서 돌리기 (대쉬 사용 시간 재는 함수)
- 대쉬 중이 아니면 SetReadyCoolTime() 호출해서 쿨타임 돌리기 (대쉬 쿨타임 Set)

### **Dash 구현**

![image](https://user-images.githubusercontent.com/77655325/201069058-a496a537-503c-493e-9029-6d37e4de2a66.png)

**Dash**
- isDash flag True로 바꿔주기
- 대쉬 때는 Agent 멈춰주기
- AddForce로 대쉬 구현

**StopDash**
- Dash 쿨타임 초기화해서 다시 시작
- rigid 초기화
- isDash false
- 다시 Agent로 움직임

### 원거리 회피는 나중에 완벽히 구현되면 쓸 예정